### PR TITLE
remove unneeded init_neighbour_search

### DIFF
--- a/touching.cpp
+++ b/touching.cpp
@@ -196,8 +196,6 @@ int main(){
      * periodic in x and y
      */
 
-    particles.init_neighbour_search(vdouble2(0,0), 5*vdouble2(length_x,length_y), vbool2(false,false));
-
 
     /*
      * compact initialisation


### PR DESCRIPTION
not sure why this init_neighbour_search is here. But it performs operations based on the particle's positions, which you haven't set yet, so it should be removed.